### PR TITLE
Stock Explorer Dashboard table fix

### DIFF
--- a/dashboard.qmd
+++ b/dashboard.qmd
@@ -85,12 +85,11 @@ ohlc = helpers.make_OHLC_table(data)
 
 #### Last Close: `{python} ohlc['date']`
 
-|    	 |                           |
+| Close	 | `{python} ohlc['close']`  |
 |:-------|--------------------------:|
 | Open	 | `{python} ohlc['open']`   |
 | High	 | `{python} ohlc['high']`   |
 | Low	 | `{python} ohlc['low']`    |
-| Close	 | `{python} ohlc['close']`  |
 | Volume | `{python} ohlc['volume']` |
 : {.striped}
 


### PR DESCRIPTION
My local version has stopped rendering with the empty column names in the markdown table. When I provide columns names, as here, it renders again.